### PR TITLE
Qulacs general estimator

### DIFF
--- a/packages/core/quri_parts/core/estimator/__init__.py
+++ b/packages/core/quri_parts/core/estimator/__init__.py
@@ -11,16 +11,7 @@
 from abc import abstractproperty
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import (
-    Callable,
-    Generic,
-    Optional,
-    Protocol,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Callable, Generic, Optional, Protocol, TypeVar, Union, cast, overload
 
 from typing_extensions import TypeAlias
 

--- a/packages/core/quri_parts/core/estimator/__init__.py
+++ b/packages/core/quri_parts/core/estimator/__init__.py
@@ -19,9 +19,7 @@ from quri_parts.core.operator import Operator, PauliLabel
 from quri_parts.core.state import (
     CircuitQuantumState,
     ParametricCircuitQuantumState,
-    ParametricQuantumStateT,
     ParametricQuantumStateVector,
-    QuantumStateT,
     QuantumStateVector,
 )
 
@@ -597,8 +595,8 @@ def create_general_estimator_from_estimator(
 
 
 def create_general_estimator_from_estimator(
-    estimator: QuantumEstimator[QuantumStateT],
-) -> GeneralQuantumEstimator[QuantumStateT, ParametricQuantumStateT]:
+    estimator: QuantumEstimator[_StateT],
+) -> GeneralQuantumEstimator[_StateT, _ParametricStateT]:
     """Creates a :class:`GeneralEstimator` from a :class:`QuantumEstimator`.
 
     Note:
@@ -612,11 +610,11 @@ def create_general_estimator_from_estimator(
     """
     concurrent_estimator = create_concurrent_estimator_from_estimator(estimator)
     parametric_estimator: ParametricQuantumEstimator[
-        ParametricQuantumStateT
+        _ParametricStateT
     ] = create_parametric_estimator_from_concurrent_estimator(concurrent_estimator)
 
     concurrent_parametric_estimator: ConcurrentParametricQuantumEstimator[
-        ParametricQuantumStateT
+        _ParametricStateT
     ] = create_concurrent_parametric_estimator_from_concurrent_estimator(
         concurrent_estimator
     )
@@ -645,8 +643,8 @@ def create_general_estimator_from_concurrent_estimator(
 
 
 def create_general_estimator_from_concurrent_estimator(
-    concurrent_estimator: ConcurrentQuantumEstimator[QuantumStateT],
-) -> GeneralQuantumEstimator[QuantumStateT, ParametricQuantumStateT]:
+    concurrent_estimator: ConcurrentQuantumEstimator[_StateT],
+) -> GeneralQuantumEstimator[_StateT, _ParametricStateT]:
     """Creates a :class:`GeneralEstimator` from a
     :class:`ConcurrentQuantumEstimator`.
 
@@ -658,11 +656,11 @@ def create_general_estimator_from_concurrent_estimator(
     """
     estimator = create_estimator_from_concurrent_estimator(concurrent_estimator)
     parametric_estimator: ParametricQuantumEstimator[
-        ParametricQuantumStateT
+        _ParametricStateT
     ] = create_parametric_estimator_from_concurrent_estimator(concurrent_estimator)
 
     concurrent_parametric_estimator: ConcurrentParametricQuantumEstimator[
-        ParametricQuantumStateT
+        _ParametricStateT
     ] = create_concurrent_parametric_estimator_from_concurrent_estimator(
         concurrent_estimator
     )

--- a/packages/core/quri_parts/core/estimator/__init__.py
+++ b/packages/core/quri_parts/core/estimator/__init__.py
@@ -491,17 +491,17 @@ class GeneralQuantumEstimator(Generic[GeneralStateT, GeneralParametricStateT]):
     using it as a callable function are:
 
     - Act as :class:`QuantumEstimator`:
-        - Estimatable, QuantumStateT -> Estimate
+        - Estimatable, GeneralStateT -> Estimate
     - Act as :class:`ConcurrentQuantumEstimator`:
-        - Estimatable, [QuantumStateT, ...] -> [Estimate, ...]
-        - [Estimatable], [QuantumStateT, ...] -> [Estimate, ...]
-        - [Estimatable, ...], QuantumStateT -> [Estimate, ...]
-        - [Estimatable, ...], [QuantumStateT] -> [Estimate, ...]
-        - [Estimatable, ...], [QuantumStateT, ...] -> [Estimate, ...]
+        - Estimatable, [GeneralStateT, ...] -> [Estimate, ...]
+        - [Estimatable], [GeneralStateT, ...] -> [Estimate, ...]
+        - [Estimatable, ...], GeneralStateT -> [Estimate, ...]
+        - [Estimatable, ...], [GeneralStateT] -> [Estimate, ...]
+        - [Estimatable, ...], [GeneralStateT, ...] -> [Estimate, ...]
     - Act as :class:`ParametricQuantumEstimator`:
-        - Estimatable, ParametricQuantumStateT, [float, ...] -> Estimate
+        - Estimatable, GeneralParametricStateT, [float, ...] -> Estimate
     - Act as :class:`ConcurrentParametricQuantumEstimator`:
-        - Estimatable, ParametricQuantumStateT, [[float, ...], ...] -> [Estimate, ...]
+        - Estimatable, GeneralParametricStateT, [[float, ...], ...] -> [Estimate, ...]
 
     When a :class:`GeneralEstimator` is called directly with one of the combinations
     above, it needs to parse the input arguments to figure out which of
@@ -559,7 +559,7 @@ class GeneralQuantumEstimator(Generic[GeneralStateT, GeneralParametricStateT]):
         self,
         op: Estimatable,
         state: GeneralParametricStateT,
-        param: Sequence[float],
+        param: Iterable[float],
     ) -> Estimate[complex]:
         """A :class:`ParametricQuantumEstimator`"""
         ...
@@ -569,7 +569,7 @@ class GeneralQuantumEstimator(Generic[GeneralStateT, GeneralParametricStateT]):
         self,
         op: Estimatable,
         state: GeneralParametricStateT,
-        param: Sequence[Sequence[float]],
+        param: Iterable[Iterable[float]],
     ) -> Iterable[Estimate[complex]]:
         """A :class:`ConcurrentParametricQuantumEstimator`"""
         ...
@@ -578,7 +578,7 @@ class GeneralQuantumEstimator(Generic[GeneralStateT, GeneralParametricStateT]):
         self,
         op: Union[Estimatable, Sequence[Estimatable]],
         state: Union[GeneralStateT, Sequence[GeneralStateT], GeneralParametricStateT],
-        param: Optional[Union[Sequence[float], Sequence[Sequence[float]]]] = None,
+        param: Optional[Union[Iterable[float], Iterable[Iterable[float]]]] = None,
     ) -> Union[Estimate[complex], Iterable[Estimate[complex]]]:
         if param is None:
             if isinstance(op, Operator) or isinstance(op, PauliLabel):
@@ -596,7 +596,7 @@ class GeneralQuantumEstimator(Generic[GeneralStateT, GeneralParametricStateT]):
         assert isinstance(op, Operator) or isinstance(op, PauliLabel)
 
         state = cast(GeneralParametricStateT, state)
-        if isinstance(param[0], Sequence):
+        if isinstance(next(iter(param)), Iterable):
             param = cast(Sequence[Sequence[float]], param)
             return self.concurrent_parametric_estimator(op, state, param)
         param = cast(Sequence[float], param)

--- a/packages/core/tests/core/estimator/test_estimator_creation.py
+++ b/packages/core/tests/core/estimator/test_estimator_creation.py
@@ -307,8 +307,26 @@ class TestGeneralEstimator(unittest.TestCase):
         assert general_estimator(self.op_0, param_state, [3, 4, 5]) == _Estimate(
             value=12 + 0j
         )
+        assert general_estimator(
+            self.op_0, param_state, np.array([0, 1, 2])
+        ) == _Estimate(value=3 + 0j)
+        assert general_estimator(
+            self.op_0, param_state, np.array([3, 4, 5])
+        ) == _Estimate(value=12 + 0j)
 
         assert general_estimator(self.op_0, param_state, [[0, 1, 2], [3, 4, 5]]) == [
+            _Estimate(value=3 + 0j),
+            _Estimate(value=12 + 0j),
+        ]
+        assert general_estimator(
+            self.op_0, param_state, [np.array([0, 1, 2]), np.array([3, 4, 5])]
+        ) == [
+            _Estimate(value=3 + 0j),
+            _Estimate(value=12 + 0j),
+        ]
+        assert general_estimator(
+            self.op_0, param_state, np.array([[0, 1, 2], [3, 4, 5]])
+        ) == [
             _Estimate(value=3 + 0j),
             _Estimate(value=12 + 0j),
         ]
@@ -362,9 +380,25 @@ class TestGeneralEstimator(unittest.TestCase):
         assert np.isclose(estimate.value, 3 * np.sqrt(2))
         estimate = general_estimator(self.op_0, param_state, [3, 4, 5])
         assert np.isclose(estimate.value, 12 * np.sqrt(2))
+        estimate = general_estimator(self.op_0, param_state, np.array([0, 1, 2]))
+        assert np.isclose(estimate.value, 3 * np.sqrt(2))
+        estimate = general_estimator(self.op_0, param_state, np.array([3, 4, 5]))
+        assert np.isclose(estimate.value, 12 * np.sqrt(2))
 
         estimates = list(
             general_estimator(self.op_0, param_state, [[0, 1, 2], [3, 4, 5]])
+        )
+        assert np.isclose(estimates[0].value, 3 * np.sqrt(2))
+        assert np.isclose(estimates[1].value, 12 * np.sqrt(2))
+        estimates = list(
+            general_estimator(
+                self.op_0, param_state, [np.array([0, 1, 2]), np.array([3, 4, 5])]
+            )
+        )
+        assert np.isclose(estimates[0].value, 3 * np.sqrt(2))
+        assert np.isclose(estimates[1].value, 12 * np.sqrt(2))
+        estimates = list(
+            general_estimator(self.op_0, param_state, np.array([[0, 1, 2], [3, 4, 5]]))
         )
         assert np.isclose(estimates[0].value, 3 * np.sqrt(2))
         assert np.isclose(estimates[1].value, 12 * np.sqrt(2))
@@ -410,8 +444,26 @@ class TestGeneralEstimator(unittest.TestCase):
         assert general_estimator(self.op_0, param_state, [3, 4, 5]) == _Estimate(
             value=12 + 0j
         )
+        assert general_estimator(
+            self.op_0, param_state, np.array([0, 1, 2])
+        ) == _Estimate(value=3 + 0j)
+        assert general_estimator(
+            self.op_0, param_state, np.array([3, 4, 5])
+        ) == _Estimate(value=12 + 0j)
 
         assert general_estimator(self.op_0, param_state, [[0, 1, 2], [3, 4, 5]]) == [
+            _Estimate(value=3 + 0j),
+            _Estimate(value=12 + 0j),
+        ]
+        assert general_estimator(
+            self.op_0, param_state, [np.array([0, 1, 2]), np.array([3, 4, 5])]
+        ) == [
+            _Estimate(value=3 + 0j),
+            _Estimate(value=12 + 0j),
+        ]
+        assert general_estimator(
+            self.op_0, param_state, np.array([[0, 1, 2], [3, 4, 5]])
+        ) == [
             _Estimate(value=3 + 0j),
             _Estimate(value=12 + 0j),
         ]
@@ -465,9 +517,25 @@ class TestGeneralEstimator(unittest.TestCase):
         assert np.isclose(estimate.value, 3 * np.sqrt(2))
         estimate = general_estimator(self.op_0, param_state, [3, 4, 5])
         assert np.isclose(estimate.value, 12 * np.sqrt(2))
+        estimate = general_estimator(self.op_0, param_state, np.array([0, 1, 2]))
+        assert np.isclose(estimate.value, 3 * np.sqrt(2))
+        estimate = general_estimator(self.op_0, param_state, np.array([3, 4, 5]))
+        assert np.isclose(estimate.value, 12 * np.sqrt(2))
 
         estimates = list(
             general_estimator(self.op_0, param_state, [[0, 1, 2], [3, 4, 5]])
+        )
+        assert np.isclose(estimates[0].value, 3 * np.sqrt(2))
+        assert np.isclose(estimates[1].value, 12 * np.sqrt(2))
+        estimates = list(
+            general_estimator(
+                self.op_0, param_state, [np.array([0, 1, 2]), np.array([3, 4, 5])]
+            )
+        )
+        assert np.isclose(estimates[0].value, 3 * np.sqrt(2))
+        assert np.isclose(estimates[1].value, 12 * np.sqrt(2))
+        estimates = list(
+            general_estimator(self.op_0, param_state, np.array([[0, 1, 2], [3, 4, 5]]))
         )
         assert np.isclose(estimates[0].value, 3 * np.sqrt(2))
         assert np.isclose(estimates[1].value, 12 * np.sqrt(2))

--- a/packages/qulacs/quri_parts/qulacs/estimator.py
+++ b/packages/qulacs/quri_parts/qulacs/estimator.py
@@ -19,6 +19,7 @@ from quri_parts.core.estimator import (
     ConcurrentQuantumEstimator,
     Estimatable,
     Estimate,
+    GeneralQuantumEstimator,
     ParametricQuantumEstimator,
     QuantumEstimator,
     create_parametric_estimator,
@@ -344,3 +345,39 @@ def create_qulacs_density_matrix_concurrent_parametric_estimator(
         )
 
     return estimator
+
+
+def create_qulacs_general_vector_estimator(
+    executor: Optional["Executor"] = None, concurrency: int = 1
+) -> GeneralQuantumEstimator[QulacsStateT, QulacsParametricStateT]:
+    """Creates a Qulacs general vector estimator."""
+    concurrent_param_estimator = create_qulacs_vector_concurrent_parametric_estimator(
+        executor, concurrency
+    )
+    return GeneralQuantumEstimator(
+        estimator=create_qulacs_vector_estimator(),
+        concurrent_estimator=create_qulacs_vector_concurrent_estimator(
+            executor, concurrency
+        ),
+        parametric_estimator=create_qulacs_vector_parametric_estimator(),
+        concurrent_parametric_estimator=concurrent_param_estimator,
+    )
+
+
+def create_qulacs_general_density_matrix_estimator(
+    model: NoiseModel, executor: Optional["Executor"] = None, concurrency: int = 1
+) -> GeneralQuantumEstimator[QulacsStateT, QulacsParametricStateT]:
+    """Creates a Qulacs general density estimator."""
+    # cp_estimator: abbreviation of concurrent parametric estimator
+    cp_estimator = create_qulacs_density_matrix_concurrent_parametric_estimator(
+        model, executor, concurrency
+    )
+
+    return GeneralQuantumEstimator(
+        estimator=create_qulacs_density_matrix_estimator(model),
+        concurrent_estimator=create_qulacs_density_matrix_concurrent_estimator(
+            model, executor, concurrency
+        ),
+        parametric_estimator=create_qulacs_density_matrix_parametric_estimator(model),
+        concurrent_parametric_estimator=cp_estimator,
+    )

--- a/packages/qulacs/tests/qulacs/estimator/test_estimator.py
+++ b/packages/qulacs/tests/qulacs/estimator/test_estimator.py
@@ -9,7 +9,6 @@
 # limitations under the License.
 
 import math
-import unittest
 from concurrent.futures import ThreadPoolExecutor
 from typing import Union
 
@@ -18,6 +17,7 @@ import pytest
 
 from quri_parts.circuit import QuantumCircuit, UnboundParametricQuantumCircuit
 from quri_parts.circuit.noise import BitFlipNoise, NoiseModel
+from quri_parts.core.estimator import GeneralQuantumEstimator
 from quri_parts.core.operator import Operator, PauliLabel, pauli_label
 from quri_parts.core.state import (
     ComputationalBasisState,
@@ -27,6 +27,7 @@ from quri_parts.core.state import (
     QuantumStateVector,
     StateVectorType,
 )
+from quri_parts.qulacs import QulacsParametricStateT, QulacsStateT
 from quri_parts.qulacs.circuit.compiled_circuit import (
     _QulacsCircuit,
     compile_circuit,
@@ -38,6 +39,7 @@ from quri_parts.qulacs.estimator import (
     create_qulacs_density_matrix_concurrent_parametric_estimator,
     create_qulacs_density_matrix_estimator,
     create_qulacs_density_matrix_parametric_estimator,
+    create_qulacs_general_density_matrix_estimator,
     create_qulacs_general_vector_estimator,
     create_qulacs_vector_concurrent_estimator,
     create_qulacs_vector_concurrent_parametric_estimator,
@@ -550,58 +552,47 @@ class TestVectorConcurrentParametricEstimator:
         assert result[4].value == pytest.approx(0 + 0.5j * (-0.5))
 
 
-class TestGeneralVectorEstimator(unittest.TestCase):
-    def setUp(self) -> None:
-        self.pauli = pauli_label("Z0 Z2 Z5")
-        self.operator = Operator(
+class TestGeneralVectorEstimator:
+    @staticmethod
+    def execute_test(
+        general_estimator: GeneralQuantumEstimator[QulacsStateT, QulacsParametricStateT]
+    ) -> None:
+        pauli = pauli_label("Z0 Z2 Z5")
+        operator = Operator(
             {
                 pauli_label("Z0 Z2 Z5"): 0.25,
                 pauli_label("Z1 Z2 Z4"): 0.5j,
             }
         )
 
-    def test_without_executor(self) -> None:
-        general_estimator = create_qulacs_general_vector_estimator()
-
         state_1 = ComputationalBasisState(6, bits=0b110000)
         state_2 = ComputationalBasisState(6, bits=0b110010)
         state_3 = create_vector_state(6, 0b110000)
 
         # test estimator
-        assert general_estimator(self.pauli, state_1) == _Estimate(value=-1, error=0)
-        assert general_estimator(self.operator, state_2) == _Estimate(
-            value=-0.25 + 0.5j, error=0
-        )
-        assert general_estimator(self.pauli, state_3) == _Estimate(value=-1, error=0)
+        estimator = create_qulacs_vector_estimator()
+        assert general_estimator(pauli, state_1) == estimator(pauli, state_1)
+        assert general_estimator(operator, state_2) == estimator(operator, state_2)
+        assert general_estimator(pauli, state_3) == estimator(pauli, state_3)
 
         # test concurrent estimator
-        assert general_estimator(self.pauli, [state_1, state_2, state_3]) == [
-            _Estimate(value=-1, error=0),
-            _Estimate(value=-1, error=0),
-            _Estimate(value=-1, error=0),
-        ]
+        concurrent_estimator = create_qulacs_vector_concurrent_estimator()
+        estimates = concurrent_estimator([pauli], [state_1, state_2, state_3])
+        assert general_estimator(pauli, [state_1, state_2, state_3]) == estimates
 
-        assert general_estimator([self.operator], [state_1, state_2, state_3]) == [
-            _Estimate(value=-0.25 - 0.5j, error=0),
-            _Estimate(value=-0.25 + 0.5j, error=0),
-            _Estimate(value=-0.25 - 0.5j, error=0),
-        ]
+        estimates = concurrent_estimator([operator], [state_1, state_2, state_3])
+        assert general_estimator([operator], [state_1, state_2, state_3]) == estimates
 
-        assert general_estimator([self.pauli, self.operator], state_1) == [
-            _Estimate(value=-1, error=0),
-            _Estimate(value=-0.25 - 0.5j, error=0),
-        ]
+        estimates = concurrent_estimator([pauli, operator], [state_1])
+        assert general_estimator([pauli, operator], state_1) == estimates
 
-        assert general_estimator([self.pauli, self.operator], [state_2]) == [
-            _Estimate(value=-1, error=0),
-            _Estimate(value=-0.25 + 0.5j, error=0),
-        ]
+        estimates = concurrent_estimator([pauli, operator], [state_2])
+        assert general_estimator([pauli, operator], [state_2]) == estimates
 
-        assert general_estimator([self.pauli, self.operator], [state_1, state_2]) == [
-            _Estimate(value=-1, error=0),
-            _Estimate(value=-0.25 + 0.5j, error=0),
-        ]
+        estimates = concurrent_estimator([pauli, operator], [state_1, state_2])
+        assert general_estimator([pauli, operator], [state_1, state_2]) == estimates
 
+        # Set up parametric
         param_circuit = parametric_circuit()
         p_circuit_state = ParametricCircuitQuantumState(
             param_circuit.qubit_count, param_circuit
@@ -611,30 +602,37 @@ class TestGeneralVectorEstimator(unittest.TestCase):
             param_circuit,
             vector=create_vector(param_circuit.qubit_count, bits=1),
         )
-        params = [
-            np.random.random(param_circuit.parameter_count).tolist() for _ in range(4)
-        ]
+        params = [np.random.random(param_circuit.parameter_count) for _ in range(4)]
 
         p_estimator = create_qulacs_vector_parametric_estimator()
         cp_estimator = create_qulacs_vector_concurrent_parametric_estimator()
 
         # test parametric estimator
-        assert general_estimator(self.pauli, p_circuit_state, params[0]) == p_estimator(
-            self.pauli, p_circuit_state, params[0]
+        assert general_estimator(pauli, p_circuit_state, params[0]) == p_estimator(
+            pauli, p_circuit_state, params[0].tolist()
         )
-        assert general_estimator(self.pauli, p_vector_state, params[0]) == p_estimator(
-            self.pauli, p_vector_state, params[0]
+        assert general_estimator(pauli, p_vector_state, params[0]) == p_estimator(
+            pauli, p_vector_state, params[0].tolist()
         )
 
         # test concurrent parametric estimator
-        cp_estimator(self.pauli, p_circuit_state, params)
-        general_estimator(self.pauli, p_circuit_state, params)
-        assert general_estimator(self.pauli, p_circuit_state, params) == cp_estimator(
-            self.pauli, p_circuit_state, params
+        cp_estimator(pauli, p_circuit_state, [ps.tolist() for ps in params])
+        general_estimator(pauli, p_circuit_state, params)
+        assert general_estimator(pauli, p_circuit_state, params) == cp_estimator(
+            pauli, p_circuit_state, [ps.tolist() for ps in params]
         )
-        assert general_estimator(self.pauli, p_vector_state, params) == cp_estimator(
-            self.pauli, p_vector_state, params
+        assert general_estimator(pauli, p_vector_state, params) == cp_estimator(
+            pauli, p_vector_state, [ps.tolist() for ps in params]
         )
+
+    def test_without_executor(self) -> None:
+        general_estimator = create_qulacs_general_vector_estimator()
+        self.execute_test(general_estimator)
+
+    def test_with_executor(self) -> None:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            general_estimator = create_qulacs_general_vector_estimator(executor, 2)
+            self.execute_test(general_estimator)
 
 
 class TestDensityMatrixEstimatorWithNoiseModel:
@@ -843,3 +841,95 @@ class TestDensityMatrixConcurrentParametricEstimatorWithNoiseModel:
         assert result[2].value == 1
         assert result[3].value == -1
         assert result[4].value == -1
+
+
+class TestGeneralDensityMatrixEstimator:
+    @staticmethod
+    def execute_test(
+        general_estimator: GeneralQuantumEstimator[
+            QulacsStateT, QulacsParametricStateT
+        ],
+        model: NoiseModel,
+    ) -> None:
+        pauli = pauli_label("Z0 Z2 Z5")
+        operator = Operator(
+            {
+                pauli_label("Z0 Z2 Z5"): 0.25,
+                pauli_label("Z1 Z2 Z4"): 0.5j,
+            }
+        )
+
+        state_1 = ComputationalBasisState(6, bits=0b110000)
+        state_2 = ComputationalBasisState(6, bits=0b110010)
+        state_3 = create_vector_state(6, 0b110000)
+
+        # test estimator
+        estimator = create_qulacs_density_matrix_estimator(model)
+        assert general_estimator(pauli, state_1) == estimator(pauli, state_1)
+        assert general_estimator(operator, state_2) == estimator(operator, state_2)
+        assert general_estimator(pauli, state_3) == estimator(pauli, state_3)
+
+        # test concurrent estimator
+        concurrent_estimator = create_qulacs_density_matrix_concurrent_estimator(model)
+        estimates = concurrent_estimator([pauli], [state_1, state_2, state_3])
+        assert general_estimator(pauli, [state_1, state_2, state_3]) == estimates
+
+        estimates = concurrent_estimator([operator], [state_1, state_2, state_3])
+        assert general_estimator([operator], [state_1, state_2, state_3]) == estimates
+
+        estimates = concurrent_estimator([pauli, operator], [state_1])
+        assert general_estimator([pauli, operator], state_1) == estimates
+
+        estimates = concurrent_estimator([pauli, operator], [state_2])
+        assert general_estimator([pauli, operator], [state_2]) == estimates
+
+        estimates = concurrent_estimator([pauli, operator], [state_1, state_2])
+        assert general_estimator([pauli, operator], [state_1, state_2]) == estimates
+
+        # Set up parametric
+        param_circuit = parametric_circuit()
+        p_circuit_state = ParametricCircuitQuantumState(
+            param_circuit.qubit_count, param_circuit
+        )
+        p_vector_state = ParametricQuantumStateVector(
+            param_circuit.qubit_count,
+            param_circuit,
+            vector=create_vector(param_circuit.qubit_count, bits=1),
+        )
+        params = [np.random.random(param_circuit.parameter_count) for _ in range(4)]
+
+        p_estimator = create_qulacs_density_matrix_parametric_estimator(model)
+        cp_estimator = create_qulacs_density_matrix_concurrent_parametric_estimator(
+            model
+        )
+
+        # test parametric estimator
+        assert general_estimator(pauli, p_circuit_state, params[0]) == p_estimator(
+            pauli, p_circuit_state, params[0].tolist()
+        )
+        assert general_estimator(pauli, p_vector_state, params[0]) == p_estimator(
+            pauli, p_vector_state, params[0].tolist()
+        )
+
+        # test concurrent parametric estimator
+        cp_estimator(pauli, p_circuit_state, [ps.tolist() for ps in params])
+        general_estimator(pauli, p_circuit_state, params)
+        assert general_estimator(pauli, p_circuit_state, params) == cp_estimator(
+            pauli, p_circuit_state, [ps.tolist() for ps in params]
+        )
+        assert general_estimator(pauli, p_vector_state, params) == cp_estimator(
+            pauli, p_vector_state, [ps.tolist() for ps in params]
+        )
+
+    def test_without_executor(self) -> None:
+        model = NoiseModel([BitFlipNoise(1.0)])
+        general_estimator = create_qulacs_general_density_matrix_estimator(model)
+        self.execute_test(general_estimator, model)
+
+    def test_with_executor(self) -> None:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            model = NoiseModel([BitFlipNoise(1.0)])
+            general_estimator = create_qulacs_general_density_matrix_estimator(
+                model, executor, 2
+            )
+            self.execute_test(general_estimator, model)


### PR DESCRIPTION
Supports Qulacs version of general estimator

## New functions:
- create_qulacs_general_vector_estimator
- create_qulacs_general_density_matrix_estimator

## Examples
```python
# For noiseless estimation
general_estimator = create_qulacs_general_vector_estimator()
# For noisy estimation
general_estimator = create_qulacs_general_density_matrix_estimator(noise_model)


# Estimate
general_estimator(op1, state1)

# Concurrent estimate
general_estimator([op1, op2], state1)
general_estimator([op1, op2], [state1])
general_estimator(op1, [state1, state2])
general_estimator([op1], [state1, state2])
general_estimator([op1, op2], [state1, state2])


# Parametric estimate
general_estimator(op1, param_state1, param_1)

# Parametric concurrent estimate
general_estimator(op1, param_state1, [param_1, param_2, ...])
```