### PR TITLE
Fix sub collector cache

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/resolve.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/resolve.py
@@ -120,7 +120,9 @@ class SubCollector:
                 if isinstance(op, Op):
                     sub_map[op] = sub
 
-                not_computed = set(o for o, _, _ in sub.operations) - set(sub_map.keys())
+                not_computed = set(o for o, _, _ in sub.operations) - set(
+                    sub_map.keys()
+                )
                 for o in not_computed:
                     _collect(o)
             elif isinstance(op, Op):

--- a/quri-parts/packages/qsub/quri_parts/qsub/resolve.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/resolve.py
@@ -105,7 +105,6 @@ class SubCollector:
 
     def collect_subs(self, op: Op | Sub) -> Mapping[Op, Sub]:
         sub_map: dict[Op, Optional[Sub]] = {}
-        subs_set: set[str] = set()
 
         def _collect(op: Op | Sub) -> None:
             if isinstance(op, Op):
@@ -120,10 +119,10 @@ class SubCollector:
                 logger.debug("Resolved: %s", sub)
                 if isinstance(op, Op):
                     sub_map[op] = sub
-                if str(sub) not in subs_set:
-                    subs_set.add(str(sub))
-                    for o, _, _ in sub.operations:
-                        _collect(o)
+
+                not_computed = set(o for o, _, _ in sub.operations) - set(sub_map.keys())
+                for o in not_computed:
+                    _collect(o)
             elif isinstance(op, Op):
                 logger.debug("Not found: %s", op.id)
                 sub_map[op] = None


### PR DESCRIPTION
Caching inside the `SubCollector` fails in the case when ArrayRef is used as an Op parameter. This is because ArrayRef is only the same as the other ArrayRef when they share the same memory address.

This PR fixes this issue by checking the which Ops in a Sub do not exist in the CallTable dictionary.