### PR TITLE
Add qubit-count validation when concatenating two circuits #389

### DIFF
--- a/quri-parts/packages/core/tests/core/state/test_state_helper.py
+++ b/quri-parts/packages/core/tests/core/state/test_state_helper.py
@@ -69,7 +69,7 @@ def test_quantum_state(
     state1 = quantum_state(n_qubits, bits=0b01)
     assert isinstance(state1, ComputationalBasisState)
 
-    circuit = QuantumCircuit(0)
+    circuit = QuantumCircuit(n_qubits)
     state2 = quantum_state(n_qubits, bits=0b01, circuit=circuit)
     assert isinstance(state2, GeneralCircuitQuantumState)
     assert _circuit_quantum_state_mock.call_count == 1

--- a/quri-parts/packages/rust/src/circuit/circuit.rs
+++ b/quri-parts/packages/rust/src/circuit/circuit.rs
@@ -120,10 +120,11 @@ impl ImmutableQuantumCircuit {
     fn combine(slf: &Bound<'_, Self>, gates: Bound<'_, PyAny>) -> PyResult<Py<QuantumCircuit>> {
         if let Ok(other) = gates.downcast::<ImmutableQuantumCircuit>() {
             let other_qubit_count = other.borrow().qubit_count;
-            if other_qubit_count != slf.borrow().qubit_count {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Cannot combine circuits with different qubit counts",
-                ));
+            let self_qubit_count = { slf.borrow().qubit_count };
+            if other_qubit_count != self_qubit_count {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "Cannot combine circuits with different qubit counts ({self_qubit_count} and {other_qubit_count})",
+                )));
             }
         }
         let ret = Self::get_mutable_copy(slf)?;

--- a/quri-parts/packages/rust/src/circuit/circuit.rs
+++ b/quri-parts/packages/rust/src/circuit/circuit.rs
@@ -135,7 +135,17 @@ impl ImmutableQuantumCircuit {
     #[pyo3(name = "__add__")]
     fn py_add(slf: &Bound<'_, Self>, gates: Bound<'_, PyAny>) -> PyResult<PyObject> {
         let py = slf.py();
-        Ok(Self::combine(slf, gates)?.into_py(py))
+        match Self::combine(slf, gates) {
+            Ok(circuit) => Ok(circuit.into_py(py)),
+            Err(err) => {
+                // propagate mismatched qubit error (or any other Value Error)
+                if err.is_instance_of::<pyo3::exceptions::PyValueError>(py) {
+                    Err(err)
+                } else {
+                    Ok(py.NotImplemented())
+                }
+            }
+        }
     }
 
     fn freeze(slf: Bound<'_, Self>) -> PyResult<Bound<'_, Self>> {

--- a/quri-parts/packages/rust/src/circuit/circuit.rs
+++ b/quri-parts/packages/rust/src/circuit/circuit.rs
@@ -133,19 +133,18 @@ impl ImmutableQuantumCircuit {
 
     #[pyo3(name = "__add__")]
     fn py_add(slf: &Bound<'_, Self>, gates: Bound<'_, PyAny>) -> PyResult<PyObject> {
+        let py = slf.py();
         match Self::combine(slf, gates) {
-        Ok(circuit) => Ok(circuit.into_py(slf.py())),
-        Err(err) => {
-            // propagate mismatched qubit error (or any other specific ones)
-            if err.is_instance_of::<pyo3::exceptions::PyValueError>(slf.py()) {
-                Err(err)
-            } else {
-                Err(pyo3::exceptions::PyNotImplementedError::new_err(
-                    err.to_string(),
-                ))
+            Ok(circuit) => Ok(circuit.into_py(py)),
+            Err(err) => {
+                // propagate mismatched qubit error (or any other Value Error)
+                if err.is_instance_of::<pyo3::exceptions::PyValueError>(py) {
+                    Err(err)
+                } else {
+                    Ok(py.NotImplemented())
+                }
             }
         }
-    }
     }
 
     fn freeze(slf: Bound<'_, Self>) -> PyResult<Bound<'_, Self>> {

--- a/quri-parts/packages/rust/src/circuit/circuit.rs
+++ b/quri-parts/packages/rust/src/circuit/circuit.rs
@@ -135,17 +135,7 @@ impl ImmutableQuantumCircuit {
     #[pyo3(name = "__add__")]
     fn py_add(slf: &Bound<'_, Self>, gates: Bound<'_, PyAny>) -> PyResult<PyObject> {
         let py = slf.py();
-        match Self::combine(slf, gates) {
-            Ok(circuit) => Ok(circuit.into_py(py)),
-            Err(err) => {
-                // propagate mismatched qubit error (or any other Value Error)
-                if err.is_instance_of::<pyo3::exceptions::PyValueError>(py) {
-                    Err(err)
-                } else {
-                    Ok(py.NotImplemented())
-                }
-            }
-        }
+        Ok(Self::combine(slf, gates)?.into_py(py))
     }
 
     fn freeze(slf: Bound<'_, Self>) -> PyResult<Bound<'_, Self>> {

--- a/quri-parts/packages/rust/src/circuit/circuit.rs
+++ b/quri-parts/packages/rust/src/circuit/circuit.rs
@@ -118,16 +118,34 @@ impl ImmutableQuantumCircuit {
 
     #[pyo3(text_signature = "(gates: ImmutableQuantumCircuit | Sequence[QuantumGate])")]
     fn combine(slf: &Bound<'_, Self>, gates: Bound<'_, PyAny>) -> PyResult<Py<QuantumCircuit>> {
+        if let Ok(other) = gates.downcast::<ImmutableQuantumCircuit>() {
+            let other_qubit_count = other.borrow().qubit_count;
+            if other_qubit_count != slf.borrow().qubit_count {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "Cannot combine circuits with different qubit counts",
+                ));
+            }
+        }
         let ret = Self::get_mutable_copy(slf)?;
         QuantumCircuit::extend(ret.bind(slf.py()), gates)?;
         Ok(ret)
     }
 
     #[pyo3(name = "__add__")]
-    fn py_add(slf: &Bound<'_, Self>, gates: Bound<'_, PyAny>) -> PyObject {
-        Self::combine(slf, gates)
-            .map(|c| c.into_py(slf.py()))
-            .unwrap_or(slf.py().NotImplemented())
+    fn py_add(slf: &Bound<'_, Self>, gates: Bound<'_, PyAny>) -> PyResult<PyObject> {
+        match Self::combine(slf, gates) {
+        Ok(circuit) => Ok(circuit.into_py(slf.py())),
+        Err(err) => {
+            // propagate mismatched qubit error (or any other specific ones)
+            if err.is_instance_of::<pyo3::exceptions::PyValueError>(slf.py()) {
+                Err(err)
+            } else {
+                Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                    err.to_string(),
+                ))
+            }
+        }
+    }
     }
 
     fn freeze(slf: Bound<'_, Self>) -> PyResult<Bound<'_, Self>> {


### PR DESCRIPTION
Fixes https://github.com/QunaSys/quri-sdk-issues/issues/414. QuantumStateVector.with_gates_applied now surfaces the “different qubit numbers” error instead of the misleading TypeError when combining a 3‑qubit state circuit with a 4‑qubit gate circuit.

- Circuits now reject mismatched qubit counts up front inside `ImmutableQuantumCircuit.combine`, so `circuit + other` raises `ValueError` with a clearer explanation.
- `ImmutableQuantumCircuit.__add__`; propagates this exception
- `ImmutableQuantumCircuit.__add__`; still raises `NotImplementedError` for all other types of errors. This necessary because, in Python when `__add__(LHS,RHS)__` raises `NotImplemented`, the Python will try to call the RHS’s `__radd__`. (For more details see discussion on original PR)