### PR TITLE
Fix MultiControlled expand bug

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/control.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/control.py
@@ -229,6 +229,7 @@ def controlled_sqrtx_resolver(op: Op, repository: SubRepository) -> Sub:
     builder = SubBuilder(op.qubit_count, op.reg_count)
     q0, q1 = builder.qubits
     _crx(builder, q0, q1, math.pi / 2)
+    builder.add_op(Phase(math.pi / 4), (q0,))
     return builder.build()
 
 
@@ -236,6 +237,7 @@ def controlled_sqrtxdag_resolver(op: Op, repository: SubRepository) -> Sub:
     builder = SubBuilder(op.qubit_count, op.reg_count)
     q0, q1 = builder.qubits
     _crx(builder, q0, q1, -math.pi / 2)
+    builder.add_op(Phase(-math.pi / 4), (q0,))
     return builder.build()
 
 
@@ -243,6 +245,7 @@ def controlled_sqrty_resolver(op: Op, repository: SubRepository) -> Sub:
     builder = SubBuilder(op.qubit_count, op.reg_count)
     q0, q1 = builder.qubits
     _cry(builder, q0, q1, math.pi / 2)
+    builder.add_op(Phase(math.pi / 4), (q0,))
     return builder.build()
 
 
@@ -250,6 +253,7 @@ def controlled_sqrtydag_resolver(op: Op, repository: SubRepository) -> Sub:
     builder = SubBuilder(op.qubit_count, op.reg_count)
     q0, q1 = builder.qubits
     _cry(builder, q0, q1, -math.pi / 2)
+    builder.add_op(Phase(-math.pi / 4), (q0,))
     return builder.build()
 
 

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
@@ -12,6 +12,8 @@ import math
 from contextlib import AbstractContextManager
 from typing import Callable
 
+import numpy as np
+
 from quri_parts.qsub.op import (
     BaseIdent,
     Op,
@@ -257,7 +259,7 @@ def MultiControlledNamedMCGatesSub(
             # Extract angle parameter from target_op
             mc_gate_factory = _mc_gate_mapping_param[target_op.base_id]
             angle = target_op.id.params[0]
-            assert isinstance(angle, float)
+            assert isinstance(angle, (float, np.float64))
             builder.add_op(mc_gate_factory(control_bits, angle), qubits)
         else:
             # Non-parametrized gates

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
@@ -438,7 +438,6 @@ def generate_multicontrolled_to_mc_sub_resolver(
                 builder.add_phase(phase)
                 phase = (-phase) % (2 * math.pi)
 
-            # generate Phase(theta)
             if phase == math.pi:
                 phase_op = Z
             elif phase == math.pi / 2:

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
@@ -413,12 +413,12 @@ def generate_multicontrolled_to_mc_sub_resolver(
                 tuple(reg_map[r] for r in rs),
             )
 
-        if target_sub.phase != 0:
-            phase = target_sub.phase % (2 * math.pi)
+        phase = target_sub.phase % (2 * math.pi)
+        if phase != 0:
+            builder.add_phase(phase / 2.0)
             if (control_value & (1 << (control_bits - 1))) == 0:
                 # use diag(e^i(phase), 1)  instead of diag(1, e^i(phase))
                 phase = (-phase) % (2 * math.pi)
-                builder.add_phase(phase)
             if phase == math.pi:
                 phase_op = Z
             elif phase == math.pi / 2:
@@ -426,7 +426,7 @@ def generate_multicontrolled_to_mc_sub_resolver(
             elif phase == 3 * math.pi / 2:
                 phase_op = Sdag
             else:
-                phase_op = Phase(phase)
+                phase_op = RZ(phase)
 
             if control_bits == 1:
                 builder.add_op(phase_op, qubits=control_q)

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
@@ -375,6 +375,8 @@ def generate_multicontrolled_to_mc_sub_resolver(
         assert isinstance(control_bits, int)
         assert isinstance(control_value, int)
 
+        # replace directly to MC? gates for named gates
+        # ex) MultiControlled[X] -> MCX
         named_sub = MultiControlledNamedMCGatesSub(
             target_op, control_bits, control_value
         )
@@ -386,7 +388,10 @@ def generate_multicontrolled_to_mc_sub_resolver(
         if target_sub_resolver is not None:
             target_sub = target_sub_resolver(target_op, repository)
 
+        # U is not found in the repository
         if target_sub is None:
+            # expand the control bits with s_and
+            # ex) MultiControlled[U] -> Toffoli + Controlled[U] + Toffoli
             return _multi_controlled_sub(target_op, control_bits, control_value, s_and)
 
         builder = SubBuilder(op.qubit_count, op.reg_count)
@@ -403,6 +408,8 @@ def generate_multicontrolled_to_mc_sub_resolver(
             zip(target_sub.aux_registers, target_ar)
         )
 
+        # expand U and emit multiple MultiControlled ops
+        # ex) MultiControlled[U] -> MultiControlled[U1] + MultiControlled[U2] + ...
         for o, qs, rs in target_sub.operations:
             if not o.unitary:
                 raise ValueError(f"Unsupported operation, {o} in multi-controlled sub")
@@ -413,12 +420,23 @@ def generate_multicontrolled_to_mc_sub_resolver(
                 tuple(reg_map[r] for r in rs),
             )
 
+        # decompose MultiControlled[theta]
+        # Controlled-theta (true condition) is decomposed as follows:
+        #   |0><0| x I + e^{i theta} |1><1> x I
+        #   = diag(1, 1, e^{i theta}, e^{i theta}) x I
+        #   = Phase(theta) x I
+        # Controlled-theta (false condition) is decomposed as follows
+        #   e^{i theta} |0><0| x I + |1><1> x I
+        #   = diag(e^{i theta}, e^{i theta}, 1, 1) x I
+        #   = e^{i theta} Phase(-theta) x I
         phase = target_sub.phase % (2 * math.pi)
         if phase != 0:
-            builder.add_phase(phase / 2.0)
             if (control_value & (1 << (control_bits - 1))) == 0:
                 # use diag(e^i(phase), 1)  instead of diag(1, e^i(phase))
+                builder.add_phase(phase)
                 phase = (-phase) % (2 * math.pi)
+
+            # generate Phase(theta)
             if phase == math.pi:
                 phase_op = Z
             elif phase == math.pi / 2:
@@ -426,7 +444,7 @@ def generate_multicontrolled_to_mc_sub_resolver(
             elif phase == 3 * math.pi / 2:
                 phase_op = Sdag
             else:
-                phase_op = RZ(phase)
+                phase_op = Phase(phase)
 
             if control_bits == 1:
                 builder.add_op(phase_op, qubits=control_q)

--- a/quri-parts/packages/qsub/tests/lib/std/test_control.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_control.py
@@ -406,6 +406,7 @@ def test_controlled_sqrtx() -> None:
         (CNOT, (q0, q1), ()),
         (RZ(math.pi / 4), (q1,), ()),
         (H, (q1,), ()),
+        (Phase(math.pi / 4), (q0,), ()),
     )
     assert sub.phase == 0
 
@@ -428,6 +429,7 @@ def test_controlled_sqrtxdag() -> None:
         (CNOT, (q0, q1), ()),
         (RZ(-math.pi / 4), (q1,), ()),
         (H, (q1,), ()),
+        (Phase(-math.pi / 4), (q0,), ()),
     )
     assert sub.phase == 0
 
@@ -448,6 +450,7 @@ def test_controlled_sqrty() -> None:
         (RY(-math.pi / 4), (q1,), ()),
         (CNOT, (q0, q1), ()),
         (RY(math.pi / 4), (q1,), ()),
+        (Phase(math.pi / 4), (q0,), ()),
     )
     assert sub.phase == 0
 
@@ -468,6 +471,7 @@ def test_controlled_sqrtydag() -> None:
         (RY(math.pi / 4), (q1,), ()),
         (CNOT, (q0, q1), ()),
         (RY(-math.pi / 4), (q1,), ()),
+        (Phase(-math.pi / 4), (q0,), ()),
     )
     assert sub.phase == 0
 

--- a/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
@@ -1635,19 +1635,10 @@ def test_mcswap_with_control_negation() -> None:
     assert sub is not None
 
 
-def test_opsub_with_multi_control_gates_in_qpe() -> None:
-    """Test creating an OpSub with CZ, Z, X, Toffoli gates and using it in
-    QPE."""
-    import numpy as np
+def test_opsub_with_multi_control_gates_recursive_subcall() -> None:
+    """Test exact circuit construction for an OpSub with recursive
+    MultiControlled subcalls."""
 
-    from quri_parts.qsub.compile import compile_sub
-    from quri_parts.qsub.eval.quriparts import QURIPartsEvaluatorHooks
-    from quri_parts.qsub.evaluate import Evaluator
-    from quri_parts.qsub.lib.qpe import QPE
-    from quri_parts.qsub.primitive import AllBasicSet, SimulatorBasicSet
-    from quri_parts.qulacs.simulator import run_circuit
-
-    # Create a custom OpSubDef with CZ, Z, X, Toffoli gates
     class MultiControlGatesOpSubDef(OpSubDef):
         name = "MultiControlGatesOp"
         qubit_count = 3
@@ -1659,42 +1650,22 @@ def test_opsub_with_multi_control_gates_in_qpe() -> None:
             builder.add_op(X, (q1,))
             builder.add_op(Toffoli, (q0, q1, q2))
 
-    # Create Op and Sub from the definition and register in repository
     repo = default_repository().copy()
-    multi_control_op, multi_control_sub = opsub(MultiControlGatesOpSubDef, repo)
-
-    # Create QPE circuit with the custom operation
-    bits = 2
-    qpe = QPE(bits, multi_control_op)
-
-    builder = SubBuilder(qpe.qubit_count)
-    builder.add_op(qpe, builder.qubits)
-    qpe_sub = builder.build()
-
-    # compile using AllBasicSet
-    compiled_qpe_sub_all = compile_sub(qpe_sub, AllBasicSet, repository=repo)
-    qp_circuit_all = (
-        Evaluator(QURIPartsEvaluatorHooks()).run(compiled_qpe_sub_all).freeze()
-    )
-
-    # compile using SimulatorBasicSet
-    repo_sim = repo.copy()
-    repo_sim.register_sub_resolver(
+    multi_control_op, _ = opsub(MultiControlGatesOpSubDef, repo)
+    repo.register_sub_resolver(
         MultiControlled, generate_multicontrolled_to_mc_sub_resolver()
     )
-    compiled = compile_sub(qpe_sub, SimulatorBasicSet, repository=repo_sim)
-    qp_circuit_sim = Evaluator(QURIPartsEvaluatorHooks()).run(compiled).freeze()
+    op = MultiControlled(multi_control_op, 2, 0b11)
+    resolved_sub = resolve_sub(op, repo)
+    assert resolved_sub is not None
+    assert len(resolved_sub.qubits) == 5
+    assert len(resolved_sub.aux_qubits) == 0
+    assert len(resolved_sub.aux_registers) == 0
 
-    # Execute both circuits using qulacs and compare state vectors
-    n_qubits_all = qp_circuit_all.qubit_count
-    initial_state_all = np.zeros(2**n_qubits_all, dtype=np.complex128)
-    initial_state_all[0] = 1.0  # |0...0⟩ state
-
-    n_qubits_sim = qp_circuit_sim.qubit_count
-    initial_state_sim = np.zeros(2**n_qubits_sim, dtype=np.complex128)
-    initial_state_sim[0] = 1.0  # |0...0⟩ state
-
-    state_vector_all = run_circuit(qp_circuit_all, initial_state_all)
-    state_vector_sim = run_circuit(qp_circuit_sim, initial_state_sim)
-
-    assert all(np.isclose(a, b) for a, b in zip(state_vector_all, state_vector_sim))
+    q0, q1, q2, q3, q4 = resolved_sub.qubits
+    assert resolved_sub.operations == (
+        (MultiControlled(CZ, 2, 0b11), (q0, q1, q2, q3), ()),
+        (MultiControlled(Z, 2, 0b11), (q0, q1, q2), ()),
+        (MultiControlled(X, 2, 0b11), (q0, q1, q3), ()),
+        (MultiControlled(Toffoli, 2, 0b11), (q0, q1, q2, q3, q4), ()),
+    )

--- a/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
@@ -1034,7 +1034,7 @@ class TestPhaseHandlingInResolver:
         op_1 = (MultiControlled(Z, 1, 0b1), resolved_sub.qubits[:2], ())
         assert resolved_sub.operations[1] == op_1
         # Global phase π is added
-        assert resolved_sub.phase == math.pi
+        assert resolved_sub.phase == math.pi / 2.0
 
     def test_phase_pi_half_with_msb_set(self) -> None:
         """Test phase π/2 handling when MSB is set in control_value."""
@@ -1130,7 +1130,7 @@ class TestPhaseHandlingInResolver:
         assert len(resolved_sub.operations) == 2
         op_0 = (MultiControlled(X, 2, 0b11), resolved_sub.qubits[:3], ())
         assert resolved_sub.operations[0] == op_0
-        expected_phase_op = MultiControlled(Phase(arbitrary_phase), 1, 0b1)
+        expected_phase_op = MultiControlled(RZ(arbitrary_phase), 1, 0b1)
         op_1 = (expected_phase_op, resolved_sub.qubits[:2], ())
         assert resolved_sub.operations[1] == op_1
 
@@ -1633,3 +1633,68 @@ def test_mcswap_with_control_negation() -> None:
     # Since MCSWAP is not implemented, this should use default behavior
     sub = resolve_sub(mc_swap_mixed, repo)
     assert sub is not None
+
+
+def test_opsub_with_multi_control_gates_in_qpe() -> None:
+    """Test creating an OpSub with CZ, Z, X, Toffoli gates and using it in
+    QPE."""
+    import numpy as np
+
+    from quri_parts.qsub.compile import compile_sub
+    from quri_parts.qsub.eval.quriparts import QURIPartsEvaluatorHooks
+    from quri_parts.qsub.evaluate import Evaluator
+    from quri_parts.qsub.lib.qpe import QPE
+    from quri_parts.qsub.primitive import AllBasicSet, SimulatorBasicSet
+    from quri_parts.qulacs.simulator import run_circuit
+
+    # Create a custom OpSubDef with CZ, Z, X, Toffoli gates
+    class MultiControlGatesOpSubDef(OpSubDef):
+        name = "MultiControlGatesOp"
+        qubit_count = 3
+
+        def sub(self, builder: SubBuilder) -> None:
+            q0, q1, q2 = builder.qubits
+            builder.add_op(CZ, (q0, q1))
+            builder.add_op(Z, (q0,))
+            builder.add_op(X, (q1,))
+            builder.add_op(Toffoli, (q0, q1, q2))
+
+    # Create Op and Sub from the definition and register in repository
+    repo = default_repository().copy()
+    multi_control_op, multi_control_sub = opsub(MultiControlGatesOpSubDef, repo)
+
+    # Create QPE circuit with the custom operation
+    bits = 2
+    qpe = QPE(bits, multi_control_op)
+
+    builder = SubBuilder(qpe.qubit_count)
+    builder.add_op(qpe, builder.qubits)
+    qpe_sub = builder.build()
+
+    # compile using AllBasicSet
+    compiled_qpe_sub_all = compile_sub(qpe_sub, AllBasicSet, repository=repo)
+    qp_circuit_all = (
+        Evaluator(QURIPartsEvaluatorHooks()).run(compiled_qpe_sub_all).freeze()
+    )
+
+    # compile using SimulatorBasicSet
+    repo_sim = repo.copy()
+    repo_sim.register_sub_resolver(
+        MultiControlled, generate_multicontrolled_to_mc_sub_resolver()
+    )
+    compiled = compile_sub(qpe_sub, SimulatorBasicSet, repository=repo_sim)
+    qp_circuit_sim = Evaluator(QURIPartsEvaluatorHooks()).run(compiled).freeze()
+
+    # Execute both circuits using qulacs and compare state vectors
+    n_qubits_all = qp_circuit_all.qubit_count
+    initial_state_all = np.zeros(2**n_qubits_all, dtype=np.complex128)
+    initial_state_all[0] = 1.0  # |0...0⟩ state
+
+    n_qubits_sim = qp_circuit_sim.qubit_count
+    initial_state_sim = np.zeros(2**n_qubits_sim, dtype=np.complex128)
+    initial_state_sim[0] = 1.0  # |0...0⟩ state
+
+    state_vector_all = run_circuit(qp_circuit_all, initial_state_all)
+    state_vector_sim = run_circuit(qp_circuit_sim, initial_state_sim)
+
+    assert all(np.isclose(a, b) for a, b in zip(state_vector_all, state_vector_sim))

--- a/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
@@ -1034,7 +1034,7 @@ class TestPhaseHandlingInResolver:
         op_1 = (MultiControlled(Z, 1, 0b1), resolved_sub.qubits[:2], ())
         assert resolved_sub.operations[1] == op_1
         # Global phase π is added
-        assert resolved_sub.phase == math.pi / 2.0
+        assert resolved_sub.phase == math.pi
 
     def test_phase_pi_half_with_msb_set(self) -> None:
         """Test phase π/2 handling when MSB is set in control_value."""
@@ -1130,7 +1130,7 @@ class TestPhaseHandlingInResolver:
         assert len(resolved_sub.operations) == 2
         op_0 = (MultiControlled(X, 2, 0b11), resolved_sub.qubits[:3], ())
         assert resolved_sub.operations[0] == op_0
-        expected_phase_op = MultiControlled(RZ(arbitrary_phase), 1, 0b1)
+        expected_phase_op = MultiControlled(Phase(arbitrary_phase), 1, 0b1)
         op_1 = (expected_phase_op, resolved_sub.qubits[:2], ())
         assert resolved_sub.operations[1] == op_1
 

--- a/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
@@ -1,6 +1,8 @@
 import math
 from typing import Sequence
 
+import pytest
+
 from quri_parts.qsub.lib.std import (
     CNOT,
     CZ,
@@ -1635,7 +1637,19 @@ def test_mcswap_with_control_negation() -> None:
     assert sub is not None
 
 
-def test_opsub_with_multi_control_gates_recursive_subcall() -> None:
+@pytest.mark.parametrize(
+    ("phase_angle", "expected_global_phase", "expected_phase_gate"),
+    (
+        (0.0, 0.0, None),
+        (math.pi, math.pi, MultiControlled(Z, 1, 0b1)),
+        (math.pi / 2, math.pi / 2, MultiControlled(Sdag, 1, 0b1)),
+        (3 * math.pi / 2, 3 * math.pi / 2, MultiControlled(S, 1, 0b1)),
+        (1.23, 1.23, MultiControlled(Phase((-1.23) % (2 * math.pi)), 1, 0b1)),
+    ),
+)
+def test_opsub_with_multi_control_gates_recursive_subcall(
+    phase_angle: float, expected_global_phase: float, expected_phase_gate: Op | None
+) -> None:
     """Test exact circuit construction for an OpSub with recursive
     MultiControlled subcalls."""
 
@@ -1649,23 +1663,28 @@ def test_opsub_with_multi_control_gates_recursive_subcall() -> None:
             builder.add_op(Z, (q0,))
             builder.add_op(X, (q1,))
             builder.add_op(Toffoli, (q0, q1, q2))
+            builder.add_phase(phase_angle)
 
     repo = default_repository().copy()
     multi_control_op, _ = opsub(MultiControlGatesOpSubDef, repo)
     repo.register_sub_resolver(
         MultiControlled, generate_multicontrolled_to_mc_sub_resolver()
     )
-    op = MultiControlled(multi_control_op, 2, 0b11)
+    op = MultiControlled(multi_control_op, 2, 0b01)
     resolved_sub = resolve_sub(op, repo)
     assert resolved_sub is not None
     assert len(resolved_sub.qubits) == 5
     assert len(resolved_sub.aux_qubits) == 0
     assert len(resolved_sub.aux_registers) == 0
+    assert math.isclose(resolved_sub.phase, expected_global_phase)
 
     q0, q1, q2, q3, q4 = resolved_sub.qubits
-    assert resolved_sub.operations == (
-        (MultiControlled(CZ, 2, 0b11), (q0, q1, q2, q3), ()),
-        (MultiControlled(Z, 2, 0b11), (q0, q1, q2), ()),
-        (MultiControlled(X, 2, 0b11), (q0, q1, q3), ()),
-        (MultiControlled(Toffoli, 2, 0b11), (q0, q1, q2, q3, q4), ()),
-    )
+    expected_operations = [
+        (MultiControlled(CZ, 2, 0b01), (q0, q1, q2, q3), ()),
+        (MultiControlled(Z, 2, 0b01), (q0, q1, q2), ()),
+        (MultiControlled(X, 2, 0b01), (q0, q1, q3), ()),
+        (MultiControlled(Toffoli, 2, 0b01), (q0, q1, q2, q3, q4), ()),
+    ]
+    if expected_phase_gate is not None:
+        expected_operations.append((expected_phase_gate, (q0, q1), ()))
+    assert resolved_sub.operations == tuple(expected_operations)


### PR DESCRIPTION
`Controlled(op)` is not correctly expanded within `generate_multicontrolled_to_mc_sub_resolver()`, when op holds famous angle phase.

# Problem

For some gates, MultiControlled[?] and MC? shows different behavior. (reported by @nils-wittemeier , discussed with @dchung0741 )

circuit:
```py
def build_controlled_sub(target_op, control_bits: int, prep_target_one: bool) -> Sub:
    qubit_count = control_bits + target_op.qubit_count
    builder = SubBuilder(qubit_count)
    control_qubits = builder.qubits[:control_bits]
    target_qubits = builder.qubits[control_bits:]

    for q in control_qubits:
        builder.add_op(std.H, (q,))
    if prep_target_one:
        for q in target_qubits:
            builder.add_op(std.X, (q,))

    control_value = (1 << control_bits) - 1
    builder.add_op(
        std.MultiControlled(target_op, control_bits, control_value),
        (*control_qubits, *target_qubits),
    )

    for q in control_qubits:
        builder.add_op(std.H, (q,))

    return builder.build()
```

failing results:
```
Gate SqrtX:
Probabilities (bitstring, |Δp|, p[AllBasic], p[MC]):
   - 00: 7.767e-02, 8.902e-01, 8.125e-01
   - 01: 2.589e-02, 3.661e-02, 6.250e-02
   - 10: 2.589e-02, 3.661e-02, 6.250e-02
   - 11: 2.589e-02, 3.661e-02, 6.250e-02

Gate SqrtXdag:
Probabilities (bitstring, |Δp|, p[AllBasic], p[MC]):
   - 00: 7.767e-02, 8.902e-01, 8.125e-01
   - 01: 2.589e-02, 3.661e-02, 6.250e-02
   - 10: 2.589e-02, 3.661e-02, 6.250e-02
   - 11: 2.589e-02, 3.661e-02, 6.250e-02

Gate SqrtY:
Probabilities (bitstring, |Δp|, p[AllBasic], p[MC]):
   - 00: 7.767e-02, 8.902e-01, 8.125e-01
   - 01: 2.589e-02, 3.661e-02, 6.250e-02
   - 10: 2.589e-02, 3.661e-02, 6.250e-02
   - 11: 2.589e-02, 3.661e-02, 6.250e-02

Gate SqrtYdag:
Probabilities (bitstring, |Δp|, p[AllBasic], p[MC]):
   - 00: 7.767e-02, 8.902e-01, 8.125e-01
   - 01: 2.589e-02, 3.661e-02, 6.250e-02
   - 10: 2.589e-02, 3.661e-02, 6.250e-02
   - 11: 2.589e-02, 3.661e-02, 6.250e-02
```

# Cause

Because the resolver does not treat global phase of U correctly.