### PR TITLE
add script to install ibm-platform-services and ibm-cloud-sdk-core manually on CI

### DIFF
--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -67,8 +67,8 @@ jobs:
     - name: Install legacy dependency
       if: matrix.python_version == '3.9'
       run: |
-        poetry run pip install -vvv "setuptools<82"
-        poetry run pip install -vvv "ibm-cloud-sdk-core~=3.18.0"
+        echo "setuptools<82" > /tmp/constraints.txt
+        poetry run pip install -vvv "ibm-cloud-sdk-core~=3.18.0" -c /tmp/constraints.txt
     - name: Install dependencies
       run: |
         poetry run pip install -vvv -e quri-parts/packages/rust

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -69,6 +69,7 @@ jobs:
       run: |
         echo "setuptools<82" > /tmp/constraints.txt
         poetry run pip install -vvv "ibm-cloud-sdk-core==3.18.0" --build-constraint /tmp/constraints.txt
+        poetry run pip install -vvv "ibm-platform-services==0.48.0" --build-constraint /tmp/constraints.txt
     - name: Install dependencies
       run: |
         poetry run pip install -vvv -e quri-parts/packages/rust

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -61,12 +61,17 @@ jobs:
       working-directory: quri-parts
       run: cargo test --workspace
 
-    - name: Install dependencies
+    - name: Choose python version
       run: |
         poetry env use ${{ matrix.python_version }}
-        poetry run pip install -vvv -e quri-parts/packages/rust
+    - name: Install legacy dependency
+      if: matrix.python_version == '3.9'
+      run: |
         poetry run pip install -vvv setuptools<82
         poetry run pip install -vvv ibm-cloud-sdk-core~=3.18.0
+    - name: Install dependencies
+      run: |
+        poetry run pip install -vvv -e quri-parts/packages/rust
         poetry install -vvv --only main,dev
 
     - name: Detect Julia project

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -65,6 +65,7 @@ jobs:
       run: |
         poetry env use ${{ matrix.python_version }}
         poetry run pip install -vvv -e quri-parts/packages/rust
+        poetry run pip install -vvv ibm-cloud-sdk-core~=3.18.0
         poetry install -vvv --only main,dev
 
     - name: Detect Julia project

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -67,8 +67,8 @@ jobs:
     - name: Install legacy dependency
       if: matrix.python_version == '3.9'
       run: |
-        poetry run pip install -vvv setuptools<82
-        poetry run pip install -vvv ibm-cloud-sdk-core~=3.18.0
+        poetry run pip install -vvv "setuptools<82"
+        poetry run pip install -vvv "ibm-cloud-sdk-core~=3.18.0"
     - name: Install dependencies
       run: |
         poetry run pip install -vvv -e quri-parts/packages/rust

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -68,7 +68,7 @@ jobs:
       if: matrix.python_version == '3.9'
       run: |
         echo "setuptools<82" > /tmp/constraints.txt
-        poetry run pip install -vvv "ibm-cloud-sdk-core~=3.18.0" --build-constraint /tmp/constraints.txt
+        poetry run pip install -vvv "ibm-cloud-sdk-core==3.18.0" --build-constraint /tmp/constraints.txt
     - name: Install dependencies
       run: |
         poetry run pip install -vvv -e quri-parts/packages/rust

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -68,7 +68,7 @@ jobs:
       if: matrix.python_version == '3.9'
       run: |
         echo "setuptools<82" > /tmp/constraints.txt
-        poetry run pip install -vvv "ibm-cloud-sdk-core~=3.18.0" -c /tmp/constraints.txt
+        poetry run pip install -vvv "ibm-cloud-sdk-core~=3.18.0" --build-constraint /tmp/constraints.txt
     - name: Install dependencies
       run: |
         poetry run pip install -vvv -e quri-parts/packages/rust

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -65,6 +65,7 @@ jobs:
       run: |
         poetry env use ${{ matrix.python_version }}
         poetry run pip install -vvv -e quri-parts/packages/rust
+        poetry run pip install -vvv setuptools<82
         poetry run pip install -vvv ibm-cloud-sdk-core~=3.18.0
         poetry install -vvv --only main,dev
 

--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -66,6 +66,9 @@ jobs:
         poetry env use ${{ matrix.python_version }}
     - name: Install legacy dependency
       if: matrix.python_version == '3.9'
+      # We need to provide older setuptools (<82) for building ibm-cloud-sdk-core and ibm-platfrom-services for Python 3.9
+      # We cannot upgrade ibm-cloud-sdk-core or ibm-platform-services since they are constrainted from Python 3.9
+      # More details: https://github.com/QunaSys/quri-sdk/pull/507
       run: |
         echo "setuptools<82" > /tmp/constraints.txt
         poetry run pip install -vvv "ibm-cloud-sdk-core==3.18.0" --build-constraint /tmp/constraints.txt


### PR DESCRIPTION
With `setuptools>=82`, building ibm-platform-services==0.48.0 and ibm-cloud-sdk-core==3.18.0 fails.
Since pip installs newer `setuptools` in each isolated environment for building a dependency package, I manually install `setuptools<82` and install ibm-platform-services and ibm-cloud-sdk-core before running poetry install (`poetry install` doesn't accept build constraint).

background: 
- we gotta support python 3.9 for HPC center as they still only support python 3.9
- python 3.9 constraints does not allow us to upgrade those ibm dependencies.
  - it's not that the newer version of those ibm package does not support python 3.9
  -  botocore 1.35.34 requires urllib3<1.27,>=1.25.4; botocore cannot be upgraded unless >=python 3.10
  -  ibm-cloud-sdk-core 3.18.0 requires urllib3<2.0.0,>=1.26.18
  - Therefore, the constraint propagates the following way
  -  python 3.9 → botocore → urllib3 → ibm-cloud-sdk