### PR TITLE
Bump version to 0.26.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6427,7 +6427,7 @@ temp = ">=2020.7.2,<2021.0.0"
 
 [[package]]
 name = "quri-algo"
-version = "0.26.2"
+version = "0.26.3"
 description = "Algorithm library based on QURI Parts"
 optional = false
 python-versions = ">=3.10,<4"
@@ -6570,6 +6570,7 @@ files = []
 develop = true
 
 [package.dependencies]
+mpmath = "^1.3.0"
 networkx = "*"
 numpy = [
     {version = ">=1.22.0,<2.0", markers = "python_version != \"3.13\""},
@@ -6792,7 +6793,7 @@ url = "quri-parts/packages/qulacs"
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.26.2"
+version = "0.26.3"
 description = "Platform-independent quantum circuit library"
 optional = false
 python-versions = "^3.9.8"
@@ -6874,7 +6875,7 @@ url = "quri-parts/packages/tket"
 
 [[package]]
 name = "quri-vm"
-version = "0.26.2"
+version = "0.26.3"
 description = ""
 optional = false
 python-versions = "<4,>=3.10"

--- a/quri-algo/pyproject.toml
+++ b/quri-algo/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quri-algo"
-version = "0.26.2"
+version = "0.26.3"
 description = "Algorithm library based on QURI Parts"
 license = "MIT"
 authors = ["QunaSys"]

--- a/quri-parts/Cargo.lock
+++ b/quri-parts/Cargo.lock
@@ -186,14 +186,14 @@ dependencies = [
 
 [[package]]
 name = "quri-parts"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "num-complex",
  "pyo3",

--- a/quri-parts/Cargo.toml
+++ b/quri-parts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quri-parts"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2021"
 description = "Platform-independent quantum computing library"
 authors = ["QURI Parts Authors <opensource@qunasys.com>"]

--- a/quri-parts/packages/rust/Cargo.toml
+++ b/quri-parts/packages/rust/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "quri-parts-rust"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2021"
 publish = false
 
 [dependencies]
 num-complex = "0.4.6"
-quri-parts = { path = "../../", version = "0.26.2", features = ["python"] }
+quri-parts = { path = "../../", version = "0.26.3", features = ["python"] }
 rayon = "1.10"
 
 [dependencies.pyo3]

--- a/quri-parts/packages/rust/pyproject.toml
+++ b/quri-parts/packages/rust/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools_rust_bundled.setuptools"
 [project]
 dependencies = ["typing-extensions>=4.1.1,<5.0.0", "numpy>=1.22.0"]
 name = "quri-parts-rust"
-version = "0.26.2"
+version = "0.26.3"
 description = "Platform-independent quantum circuit library"
 license = { text = "Apache-2.0" }
 
@@ -38,7 +38,7 @@ Documentation = "https://quri-parts.qunasys.com"
 # The followings is needed for rust-sdist-package CI
 [tool.poetry]
 name = "quri-parts-rust"
-version = "0.26.2"
+version = "0.26.3"
 description = "Platform-independent quantum circuit library"
 license = "Apache-2.0"
 authors = ["QURI Parts Authors <opensource@qunasys.com>"]

--- a/quri-vm/pyproject.toml
+++ b/quri-vm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quri-vm"
-version = "0.26.2"
+version = "0.26.3"
 description = ""
 authors = ["QunaSys"]
 readme = "README.md"


### PR DESCRIPTION
Bump quri-parts, quri-algo, and quri-vm to `0.26.3` (patch). Updates version numbers in the package tomls and refreshes `Cargo.lock` / `poetry.lock`.

