### PR TITLE
Bump version to 0.26.4; run package CI on release PRs

### DIFF
--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -117,15 +117,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP (debugging kraus_operators failure): trimmed to the failing cells
-        # only. Restore { ubuntu, macos, windows } x [ "10", "14" ] + the
-        # windows-14 exclude before merge.
         system:
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
-        python-version: [ "14" ]
+          - os: "windows-latest"
+            target: "x86_64-pc-windows-msvc"
+        python-version: [ "10", "14" ]
+        # Currently, qulacsvis does not support Python3.14&&Windows environment (ref: Qulacs-Osaka/qulacs-visualizer#138)
+        exclude:
+          - python-version: "14"
+            system:
+              os: "windows-latest"
     defaults:
       run:
         shell: bash
@@ -239,13 +243,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP (debugging): windows wheels pass, dropped to save resources.
-        # Restore the windows-latest entry before merge.
         system:
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
+          - os: "windows-latest"
+            target: "x86_64-pc-windows-msvc"
     defaults:
       run:
         shell: bash
@@ -325,15 +329,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP (debugging kraus_operators failure): trimmed to the failing cells
-        # only. Restore { ubuntu, macos, windows } x [ "10"-"14" ] + the
-        # windows-14 exclude before merge.
         system:
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
-        python-version: [ "12", "14" ]
+          - os: "windows-latest"
+            target: "x86_64-pc-windows-msvc"
+        python-version: [ "10", "11", "12", "13", "14" ]
+        # Currently, qulacsvis does not support Python3.14&&Windows environment (ref: Qulacs-Osaka/qulacs-visualizer#138)
+        exclude:
+          - python-version: "14"
+            system:
+              os: "windows-latest"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -243,13 +243,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TEMP (debugging macos wheel kraus_operators/transpile failures): built
+        # macos wheel only. Restore { ubuntu, macos, windows } before merge.
         system:
-          - os: "ubuntu-latest"
-            target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
-          - os: "windows-latest"
-            target: "x86_64-pc-windows-msvc"
     defaults:
       run:
         shell: bash
@@ -329,19 +327,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TEMP (debugging macos wheel kraus_operators/transpile failures):
+        # trimmed to the failing macos cells only. Restore { ubuntu, macos,
+        # windows } x [ "10"-"14" ] + the windows-14 exclude before merge.
         system:
-          - os: "ubuntu-latest"
-            target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
-          - os: "windows-latest"
-            target: "x86_64-pc-windows-msvc"
         python-version: [ "10", "11", "12", "13", "14" ]
-        # Currently, qulacsvis does not support Python3.14&&Windows environment (ref: Qulacs-Osaka/qulacs-visualizer#138)
-        exclude:
-          - python-version: "14"
-            system:
-              os: "windows-latest"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -407,12 +407,18 @@ jobs:
           if [[ "${{ runner.os }}" = "Linux" ]]; then
               sudo apt install -y libjpeg-dev
           fi
+          # Collect every locally built wheel and install them in ONE pip pass.
+          # Installing them separately let a package's `quri-parts-* = "*"` dep
+          # resolve from PyPI before the matching local wheel was installed;
+          # since the local wheels are dev pre-releases, pip fell back to the
+          # last final release, shadowing the code under test. Passing
+          # all wheels together makes each explicit wheel satisfy the others'
+          # deps, so there is no PyPI fallback for quri-parts-* packages.
+          FILES=()
           if [[ "${{ runner.os }}" = "Linux" ]]; then
-              pip install quri-parts/dist/quri_parts*.manylinux2014_x86_64.whl
+            FILES+=($(find quri-parts/dist -name 'quri_parts*.manylinux2014_x86_64.whl'))
           else
-            for FILE in "$(find quri-parts/dist -name 'quri_parts*.whl')"; do
-              pip install -v $FILE
-            done
+            FILES+=($(find quri-parts/dist -name 'quri_parts*.whl'))
           fi
           for FILE in $(find quri-parts/dist_py -name '*.whl'); do
             if [[ "${{ matrix.system.os }}" == "windows-latest" ]]; then
@@ -427,9 +433,11 @@ jobs:
             if [[ "3.${{matrix.python-version}}" = "3.14" && "$FILE" = *"quri_parts_qiskit"* ]]; then
               continue
             fi
-            # pyqret is not on PyPI; supply it from the QunaSys release feed.
-            pip install -v $FILE --find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2
+            FILES+=("$FILE")
           done
+          # pyqret is not on PyPI; supply it from the QunaSys release feed.
+          pip install -v "${FILES[@]}" \
+            --find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2
 
       - name: Run test
         shell: bash

--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -243,11 +243,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP (debugging macos wheel kraus_operators/transpile failures): built
-        # macos wheel only. Restore { ubuntu, macos, windows } before merge.
         system:
+          - os: "ubuntu-latest"
+            target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
+          - os: "windows-latest"
+            target: "x86_64-pc-windows-msvc"
     defaults:
       run:
         shell: bash
@@ -327,13 +329,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMP (debugging macos wheel kraus_operators/transpile failures):
-        # trimmed to the failing macos cells only. Restore { ubuntu, macos,
-        # windows } x [ "10"-"14" ] + the windows-14 exclude before merge.
         system:
+          - os: "ubuntu-latest"
+            target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
+          - os: "windows-latest"
+            target: "x86_64-pc-windows-msvc"
         python-version: [ "10", "11", "12", "13", "14" ]
+        # Currently, qulacsvis does not support Python3.14&&Windows environment (ref: Qulacs-Osaka/qulacs-visualizer#138)
+        exclude:
+          - python-version: "14"
+            system:
+              os: "windows-latest"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -3,10 +3,17 @@ name: QURI SDK Package and release
 on:
   release:
     types: [published]
+  # Also run the build/test matrix on release PRs so failures surface before
+  # the release is published. The version-check step and all `release-*` upload
+  # jobs stay release-only. Gated to `release-*` branches via the pre-check job
+  # `if`, so ordinary PRs skip the whole (expensive) matrix.
+  pull_request:
+    branches: [main]
 
 jobs:
   pre-check:
     name: 🔎 Check project versions
+    if: github.event_name == 'release' || startsWith(github.head_ref, 'release-')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -18,6 +25,9 @@ jobs:
         fetch-depth: 0
 
     - name: check manual versioning
+      # On a release PR the new tag does not exist yet, so this would compare
+      # against the previous tag and fail. Enforce it only at release time.
+      if: github.event_name == 'release'
       shell: bash
       run: |
         GIT_VERSION_TAG="$(git describe --tags --abbrev=0 | head -n 1)"

--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -117,19 +117,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TEMP (debugging kraus_operators failure): trimmed to the failing cells
+        # only. Restore { ubuntu, macos, windows } x [ "10", "14" ] + the
+        # windows-14 exclude before merge.
         system:
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
-          - os: "windows-latest"
-            target: "x86_64-pc-windows-msvc"
-        python-version: [ "10", "14" ]
-        # Currently, qulacsvis does not support Python3.14&&Windows environment (ref: Qulacs-Osaka/qulacs-visualizer#138)
-        exclude:
-          - python-version: "14"
-            system:
-              os: "windows-latest"
+        python-version: [ "14" ]
     defaults:
       run:
         shell: bash
@@ -243,13 +239,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TEMP (debugging): windows wheels pass, dropped to save resources.
+        # Restore the windows-latest entry before merge.
         system:
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
-          - os: "windows-latest"
-            target: "x86_64-pc-windows-msvc"
     defaults:
       run:
         shell: bash
@@ -329,19 +325,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TEMP (debugging kraus_operators failure): trimmed to the failing cells
+        # only. Restore { ubuntu, macos, windows } x [ "10"-"14" ] + the
+        # windows-14 exclude before merge.
         system:
           - os: "ubuntu-latest"
             target: "x86_64-unknown-linux-gnu"
           - os: "macos-latest"
             target: "aarch64-apple-darwin"
-          - os: "windows-latest"
-            target: "x86_64-pc-windows-msvc"
-        python-version: [ "10", "11", "12", "13", "14" ]
-        # Currentl, qulacsvis does not support Python3.14&&Windows environment (ref: Qulacs-Osaka/qulacs-visualizer#138)
-        exclude:
-          - python-version: "14"
-            system:
-              os: "windows-latest"
+        python-version: [ "12", "14" ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -4,11 +4,12 @@ on:
   release:
     types: [published]
   # Also run the build/test matrix on release PRs so failures surface before
-  # the release is published. The version-check step and all `release-*` upload
-  # jobs stay release-only. Gated to `release-*` branches via the pre-check job
-  # `if`, so ordinary PRs skip the whole (expensive) matrix.
+  # the release is published. Gated to `release-*` head branches via the
+  # pre-check job `if` (ordinary PRs skip the expensive matrix); no base-branch
+  # filter, so it still fires when a release PR is stacked on another branch
+  # (e.g. based on `drop-py39` rather than `main`). The version-check step and
+  # all `release-*` upload jobs stay release-only.
   pull_request:
-    branches: [main]
 
 jobs:
   pre-check:

--- a/poetry.lock
+++ b/poetry.lock
@@ -5954,7 +5954,7 @@ temp = ">=2020.7.2,<2021.0.0"
 
 [[package]]
 name = "quri-algo"
-version = "0.26.3"
+version = "0.26.4"
 description = "Algorithm library based on QURI Parts"
 optional = false
 python-versions = ">=3.10,<4"
@@ -6317,7 +6317,7 @@ url = "quri-parts/packages/qulacs"
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.26.3"
+version = "0.26.4"
 description = "Platform-independent quantum circuit library"
 optional = false
 python-versions = "^3.10"
@@ -6399,7 +6399,7 @@ url = "quri-parts/packages/tket"
 
 [[package]]
 name = "quri-vm"
-version = "0.26.3"
+version = "0.26.4"
 description = ""
 optional = false
 python-versions = "<4,>=3.10"

--- a/quri-algo/pyproject.toml
+++ b/quri-algo/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quri-algo"
-version = "0.26.3"
+version = "0.26.4"
 description = "Algorithm library based on QURI Parts"
 license = "MIT"
 authors = ["QunaSys"]

--- a/quri-parts/Cargo.lock
+++ b/quri-parts/Cargo.lock
@@ -160,14 +160,14 @@ dependencies = [
 
 [[package]]
 name = "quri-parts"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "num-complex",
  "pyo3",

--- a/quri-parts/Cargo.toml
+++ b/quri-parts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quri-parts"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2021"
 description = "Platform-independent quantum computing library"
 authors = ["QURI Parts Authors <opensource@qunasys.com>"]

--- a/quri-parts/packages/rust/Cargo.toml
+++ b/quri-parts/packages/rust/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "quri-parts-rust"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2021"
 publish = false
 
 [dependencies]
 num-complex = "0.4.6"
-quri-parts = { path = "../../", version = "0.26.3", features = ["python"] }
+quri-parts = { path = "../../", version = "0.26.4", features = ["python"] }
 rayon = "1.10"
 
 [dependencies.pyo3]

--- a/quri-parts/packages/rust/pyproject.toml
+++ b/quri-parts/packages/rust/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools_rust_bundled.setuptools"
 [project]
 dependencies = ["typing-extensions>=4.1.1,<5.0.0", "numpy>=1.22.0"]
 name = "quri-parts-rust"
-version = "0.26.3"
+version = "0.26.4"
 description = "Platform-independent quantum circuit library"
 license = { text = "Apache-2.0" }
 
@@ -38,7 +38,7 @@ Documentation = "https://quri-parts.qunasys.com"
 # The followings is needed for rust-sdist-package CI
 [tool.poetry]
 name = "quri-parts-rust"
-version = "0.26.3"
+version = "0.26.4"
 description = "Platform-independent quantum circuit library"
 license = "Apache-2.0"
 authors = ["QURI Parts Authors <opensource@qunasys.com>"]

--- a/quri-vm/pyproject.toml
+++ b/quri-vm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quri-vm"
-version = "0.26.3"
+version = "0.26.4"
 description = ""
 authors = ["QunaSys"]
 readme = "README.md"


### PR DESCRIPTION
## What

- Bump quri-parts, quri-algo, quri-vm to `0.26.4` (patch).
- Run the `QURI SDK Package and release` build/test matrix on **release PRs**, not only at release time.
- Fix a nondeterministic wheel/sdist-test install bug that let stale PyPI packages shadow the code under test.

## Why

**Run the matrix on release PRs.** The package workflow only triggered on `release: published`, so the sdist/wheel build+test jobs ran *after* the tag was cut — a failure (e.g. the macOS sdist test failure on the v0.26.3 release) could only be caught post-release. Running the same matrix on the release PR surfaces those failures before publishing.

**Install fix.** With the matrix now running on the PR, the macOS wheel-test cells failed intermittently: `TOFFOLI2CNOTTTranspiler` / `rz2hst` import errors and a `kraus_operators: must be real number, not complex` error — symbols that exist in the source under test but were missing from the *installed* `quri_parts.circuit`. Root cause: the test step installed each local wheel in a separate `pip install`. Local wheels are dev pre-releases (dynamic-versioned off the last tag, e.g. `0.26.3.postN.devM`), and inter-package deps are unpinned (`quri-parts-* = "*"`). When a package installed before its local `quri-parts-circuit` wheel was in place, pip resolved that dep from PyPI — and since pip skips pre-releases for a `*` requirement, it pulled the last **final** release (`0.26.3`), which predates those symbols. Whether the stale version survived depended on `find`'s filesystem-iteration order, so it flaked per run/OS.

## How

- Added a `pull_request` trigger with **no base-branch filter**, gated to `release-*` head branches via the `pre-check` job `if` (`github.event_name == 'release' || startsWith(github.head_ref, 'release-')`). Every build/test job chains from `pre-check` via `needs`, so ordinary PRs skip the whole matrix; only release PRs run it, regardless of the base branch (e.g. a release PR stacked on `drop-py39`).
- The version-check step runs release-only (the new tag doesn't exist yet on the PR).
- All `release-*` PyPI-upload jobs keep their `if: github.event_name == 'release'` guard, so nothing is published from a PR.
- **Wheel-test install:** collect every locally built wheel into one list and install them in a single `pip install` pass. Each explicit wheel then satisfies the others' `quri-parts-* = "*"` deps, so there is no PyPI fallback and tests run against the built code. Deterministic across all OSes.
