### PR TITLE
Fix qubit count mismatch in 2_states tutorial notebook

### DIFF
--- a/notebooks/quri_sdk_notebooks/tutorials/3_quri-parts/0_basics/2_states/2_states.ipynb
+++ b/notebooks/quri_sdk_notebooks/tutorials/3_quri-parts/0_basics/2_states/2_states.ipynb
@@ -382,7 +382,7 @@
         "\n",
         "# Apply a circuit to a ComputationalBasisState.\n",
         "new_state1 = apply_circuit(\n",
-        "    QuantumCircuit(2, gates=[X(1)]), cb_state\n",
+        "    QuantumCircuit(5, gates=[X(1)]), cb_state\n",
         ")  # GeneralCircuitQuantumState\n",
         "\n",
         "# Apply a circuit to a GeneralCircuitQuantumState.\n",


### PR DESCRIPTION
## Summary

`apply_circuit` was called with a 2-qubit circuit on the 5-qubit `cb_state` in the `2_states` tutorial notebook. quri-parts now validates qubit counts when combining circuits with states, which makes that notebook cell fail; this went unnoticed because the `notebooks-check-execute-all` workflow only triggers on lock-file changes and had not run since the validation was introduced.