### PR TITLE
Add missing MIT license header to 6 modules

### DIFF
--- a/quri-algo/quri_algo/algo/phase_estimation/qpe/qpe.py
+++ b/quri-algo/quri_algo/algo/phase_estimation/qpe/qpe.py
@@ -1,3 +1,13 @@
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://mit-license.org/
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from math import pi
 from typing import Any, Final, Mapping, Optional, Sequence
 

--- a/quri-algo/quri_algo/circuit_lib/time_evolution/interface.py
+++ b/quri-algo/quri_algo/circuit_lib/time_evolution/interface.py
@@ -1,3 +1,13 @@
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://mit-license.org/
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # NOTE: This module has a deprecated counterpart at
 # quri_algo/qsub/time_evolution/interface.py which re-exports from here.
 from typing import Any, Protocol

--- a/quri-algo/quri_algo/circuit_lib/time_evolution/trotter_time_evo.py
+++ b/quri-algo/quri_algo/circuit_lib/time_evolution/trotter_time_evo.py
@@ -1,3 +1,13 @@
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://mit-license.org/
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # NOTE: This module has a deprecated counterpart at
 # quri_algo/qsub/time_evolution/trotter_time_evo.py which re-exports from here.
 from typing import Any, Sequence

--- a/quri-algo/quri_algo/qsub/time_evolution/interface.py
+++ b/quri-algo/quri_algo/qsub/time_evolution/interface.py
@@ -1,3 +1,13 @@
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://mit-license.org/
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import warnings
 
 warnings.warn(

--- a/quri-algo/quri_algo/qsub/time_evolution/trotter_time_evo.py
+++ b/quri-algo/quri_algo/qsub/time_evolution/trotter_time_evo.py
@@ -1,3 +1,13 @@
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://mit-license.org/
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Deprecated.
 
 Use :mod:`quri_algo.circuit_lib.time_evolution.trotter_time_evo`.

--- a/quri-vm/quri_vm/devices/collection.py
+++ b/quri-vm/quri_vm/devices/collection.py
@@ -1,3 +1,13 @@
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      https://mit-license.org/
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, auto


### PR DESCRIPTION
## Summary
- `quri-vm/quri_vm/devices/collection.py` was missing the standard MIT header (spotted while reviewing #440).
- A repo-wide sweep for non-empty `.py` files missing the same header (excluding vendored `quri-parts`, which is Apache-2.0 licensed) turned up 5 more, all in `quri-algo`.
- Header text and MIT licensing confirmed to match `quri-vm/LICENSE` and `quri-algo/LICENSE`.