### PR TITLE
Accept NumPy scalar angles in MC rotation gates

### DIFF
--- a/quri-parts/packages/circuit/quri_parts/circuit/gates.py
+++ b/quri-parts/packages/circuit/quri_parts/circuit/gates.py
@@ -409,9 +409,6 @@ class MCRXFactory:
     def __call__(
         self, target_index: int, angle: float, control_indices: Sequence[int] = []
     ) -> QuantumGate:
-        assert (
-            type(angle) is float
-        ), f"angle must be a float, {type(angle),angle=}"  # noqa: E231
         if len(control_indices) == 0:
             return QuantumGate(
                 name=self.name, params=(angle,), target_indices=(target_index,)
@@ -434,9 +431,6 @@ class MCRYFactory:
     def __call__(
         self, target_index: int, angle: float, control_indices: Sequence[int] = []
     ) -> QuantumGate:
-        assert (
-            type(angle) is float
-        ), f"angle must be a float, {type(angle),angle=}"  # noqa: E231
         if len(control_indices) == 0:
             return QuantumGate(
                 name=self.name, params=(angle,), target_indices=(target_index,)
@@ -459,9 +453,6 @@ class MCRZFactory:
     def __call__(
         self, target_index: int, angle: float, control_indices: Sequence[int] = []
     ) -> QuantumGate:
-        assert (
-            type(angle) is float
-        ), f"angle must be a float, {type(angle),angle=}"  # noqa: E231
         if len(control_indices) == 0:
             return QuantumGate(
                 name=self.name, params=(angle,), target_indices=(target_index,)
@@ -484,9 +475,6 @@ class MCU1Factory:
     def __call__(
         self, target_index: int, angle: float, control_indices: Sequence[int] = []
     ) -> QuantumGate:
-        assert (
-            type(angle) is float
-        ), f"angle must be a float, {type(angle),angle=}"  # noqa: E231
         if len(control_indices) == 0:
             return QuantumGate(
                 name=self.name, params=(angle,), target_indices=(target_index,)

--- a/quri-parts/packages/circuit/tests/circuit/test_gates.py
+++ b/quri-parts/packages/circuit/tests/circuit/test_gates.py
@@ -43,6 +43,7 @@ from quri_parts.circuit import (
     Z,
     gate_names,
 )
+from quri_parts.circuit.gates import MCRX, MCRY, MCRZ, MCU1
 
 _factory_name_map: Mapping[Callable[[int], QuantumGate], str] = {
     Identity: gate_names.Identity,
@@ -159,6 +160,14 @@ def test_gate_creation() -> None:
     assert Measurement([5], [7]) == QuantumGate(
         gate_names.Measurement, target_indices=(5,), classical_indices=(7,)
     )
+
+
+@pytest.mark.parametrize("factory", (MCRX, MCRY, MCRZ, MCU1))
+def test_mc_rotation_gate_accepts_numpy_scalar_angle(
+    factory: Callable[..., QuantumGate],
+) -> None:
+    gate = factory(1, np.float64(0.5), [0])
+    assert gate.params == (0.5,)
 
 
 def test_gate_addition() -> None:

--- a/quri-parts/packages/circuit/tests/circuit/test_gates.py
+++ b/quri-parts/packages/circuit/tests/circuit/test_gates.py
@@ -163,11 +163,15 @@ def test_gate_creation() -> None:
 
 
 @pytest.mark.parametrize("factory", (MCRX, MCRY, MCRZ, MCU1))
-def test_mc_rotation_gate_accepts_numpy_scalar_angle(
+def test_mc_rotation_gate_angle_types(
     factory: Callable[..., QuantumGate],
 ) -> None:
-    gate = factory(1, np.float64(0.5), [0])
-    assert gate.params == (0.5,)
+    for angle in (0.5, 1, np.float32(0.5), np.float64(0.5)):
+        gate = factory(1, angle, [0])
+        assert gate.params == (float(angle),)
+
+    with pytest.raises(TypeError):
+        factory(1, "0.5", [0])
 
 
 def test_gate_addition() -> None:

--- a/quri-parts/packages/circuit/tests/circuit/test_gates.py
+++ b/quri-parts/packages/circuit/tests/circuit/test_gates.py
@@ -166,14 +166,10 @@ def test_gate_creation() -> None:
 def test_mc_rotation_gate_angle_types(
     factory: Callable[..., QuantumGate],
 ) -> None:
-    for angle, expected in (
-        (0.5, 0.5),
-        (1, 1.0),
-        (np.float32(0.5), 0.5),
-        (np.float64(0.5), 0.5),
-    ):
-        gate = factory(1, angle, [0])
-        assert gate.params == (expected,)
+    assert factory(1, 0.5, [0]).params == (0.5,)
+    assert factory(1, 1, [0]).params == (1.0,)
+    assert factory(1, np.float32(0.5), [0]).params == (0.5,)
+    assert factory(1, np.float64(0.5), [0]).params == (0.5,)
 
     with pytest.raises(TypeError):
         factory(1, "0.5", [0])

--- a/quri-parts/packages/circuit/tests/circuit/test_gates.py
+++ b/quri-parts/packages/circuit/tests/circuit/test_gates.py
@@ -166,9 +166,14 @@ def test_gate_creation() -> None:
 def test_mc_rotation_gate_angle_types(
     factory: Callable[..., QuantumGate],
 ) -> None:
-    for angle in (0.5, 1, np.float32(0.5), np.float64(0.5)):
+    for angle, expected in (
+        (0.5, 0.5),
+        (1, 1.0),
+        (np.float32(0.5), 0.5),
+        (np.float64(0.5), 0.5),
+    ):
         gate = factory(1, angle, [0])
-        assert gate.params == (float(angle),)
+        assert gate.params == (expected,)
 
     with pytest.raises(TypeError):
         factory(1, "0.5", [0])


### PR DESCRIPTION
## Issue

N/A

## Changes

Changes proposed in this pull-request

- Remove Python-level angle type restrictions from multi-controlled rotation gate factories to align them with standard rotation gates.
- Add regression coverage for the aligned angle type handling.

## Progress

- [x] Main implementation written
- [x] Functions as intended
- [x] Unit tests have been written
- [ ] readme.md has been updated
