### PR TITLE
Add Cbz/Label conversion support

### DIFF
--- a/quri-parts/packages/qret/quri_parts/qret/convert_qsub.py
+++ b/quri-parts/packages/qret/quri_parts/qret/convert_qsub.py
@@ -5,7 +5,7 @@ from pyqret.frontend import Argument, CircuitBuilder, CircuitGenerator, Context,
 from pyqret.frontend import Qubit as QretQubit
 from pyqret.frontend import Qubits as QretQubits
 from pyqret.frontend import Register as QretRegister
-from pyqret.frontend.gate import intrinsic
+from pyqret.frontend.gate import control_flow, intrinsic
 
 from quri_parts.qsub.codegen import CodeGenerator
 from quri_parts.qsub.lib import std
@@ -22,6 +22,8 @@ from quri_parts.qsub.resolve import SubCollector, SubRepository, default_reposit
 
 QRETInstrSet: Iterable[AbstractOp] = (
     std.M,
+    std.Cbz,
+    std.Label,
     std.Identity,
     std.X,
     std.Y,
@@ -82,12 +84,26 @@ def generate_qubits(qubit_list: Sequence[QretQubit]) -> QretQubits:
 
 
 def _add_intrinsic(
-    mop: MachineOp, qs: Sequence[QretQubit], rs: Sequence[QretRegister]
+    mop: MachineOp,
+    qs: Sequence[QretQubit],
+    rs: Sequence[QretRegister],
+    branch_conditions: dict[QretRegister, QretRegister],
 ) -> None:
     op = mop.op
     base_id = op.base_id
     if op in _meas_instr_map:
         _meas_instr_map[op](qs[0], rs[0])
+    elif op == std.Cbz:
+        condition, label = rs
+        control_flow.qu_if(condition)
+        branch_conditions[label] = condition
+    elif op == std.Label:
+        (label,) = rs
+        try:
+            condition = branch_conditions.pop(label)
+        except KeyError as e:
+            raise ValueError(f"Label without a matching Cbz: {op}") from e
+        control_flow.qu_end_if(condition)
     elif op in _unary_instr_map:
         _unary_instr_map[op](qs[0])
     elif base_id in _param_unary_instr_map:
@@ -160,12 +176,13 @@ def _create_circuit_gen(
                 cast(QretRegister, arg[f"ar{i}"])
                 for i in range(len(msub.aux_registers), local_aux_register_count)
             ]
+            branch_conditions: dict[QretRegister, QretRegister] = {}
 
             for mop, qs, rs in msub.instructions:
                 mapped_qs = tuple(qubit_map[q] for q in qs)
                 mapped_rs = tuple(register_map[r] for r in rs)
                 if is_primitive(mop):
-                    _add_intrinsic(mop, mapped_qs, mapped_rs)
+                    _add_intrinsic(mop, mapped_qs, mapped_rs, branch_conditions)
                 elif is_subcall(mop):
                     ancilla_count = ancilla_counts[mop.op]
                     aux_register_count = aux_register_counts[mop.op]
@@ -175,6 +192,9 @@ def _create_circuit_gen(
                         list(mapped_rs) + aux_registers[:aux_register_count],
                         op_circuit_gen_map,
                     )
+
+            if branch_conditions:
+                raise ValueError("Cbz without a matching Label")
 
     return _Gen(builder)
 

--- a/quri-parts/packages/qret/tests/test_convert_qsub.py
+++ b/quri-parts/packages/qret/tests/test_convert_qsub.py
@@ -3,7 +3,7 @@ import pytest
 import quri_parts.qsub.lib.std as std
 from quri_parts.qret.convert_qsub import create_module_from_qsub_op
 from quri_parts.qsub.lib.qpe import QPE
-from quri_parts.qsub.opsub import UnitarySubDef, opsub
+from quri_parts.qsub.opsub import NonUnitarySubDef, UnitarySubDef, opsub
 from quri_parts.qsub.sub import SubBuilder
 
 
@@ -31,6 +31,22 @@ class _UMCX(UnitarySubDef):
 
 
 UMCX, _ = opsub(_UMCX)
+
+
+class _Conditional(NonUnitarySubDef):
+    name = "Conditional"
+    qubit_count = 1
+    reg_count = 1
+
+    def sub(self, builder: SubBuilder) -> None:
+        (q0,) = builder.qubits
+        (r0,) = builder.registers
+        builder.add_op(std.M, (q0,), (r0,))
+        with std.conditional(builder, r0):
+            builder.add_op(std.X, (q0,))
+
+
+Conditional, _ = opsub(_Conditional)
 
 
 class TestCreateModuleFromQsubOp:
@@ -78,6 +94,14 @@ class TestCreateModuleFromQsubOp:
         assert len(circuits_without_wrapper) == 1
         assert custom_entry_name not in circuits_without_wrapper
         assert any("UMCX" in name for name in circuits_without_wrapper)
+
+    def test_create_module_from_conditional_op(self) -> None:
+        module = create_module_from_qsub_op(Conditional)
+
+        circuit = module.get_circuit(Conditional.id.to_str())
+        ir_blocks = list(circuit.get_ir())
+        assert len(ir_blocks) > 1
+        assert "entry" in circuit.get_ir().gen_cfg()
 
     @pytest.mark.parametrize("control_bits", [2, 3, 4])
     def test_create_module_from_single_mcx_op(self, control_bits: int) -> None:


### PR DESCRIPTION
## Summary

Add qsub-to-Quration conversion support for Cbz/Label control flow.

The converter maps a zero-branch and its label to Quration's structured conditional API, preserving the condition register and rejecting unmatched branch markers.